### PR TITLE
fix:caret browsing should be false to avoid html element blinking

### DIFF
--- a/Source/Platform/Linux/Avalonia.WebView.Linux/Core/LinuxWebViewCore-override.cs
+++ b/Source/Platform/Linux/Avalonia.WebView.Linux/Core/LinuxWebViewCore-override.cs
@@ -28,7 +28,7 @@ partial class LinuxWebViewCore
                 WebView.Settings.AllowTopNavigationToDataUrls = true;
                 WebView.Settings.AllowUniversalAccessFromFileUrls = true;
                 WebView.Settings.EnableBackForwardNavigationGestures = true;
-                WebView.Settings.EnableCaretBrowsing = true;
+                WebView.Settings.EnableCaretBrowsing = false;
                 WebView.Settings.EnableMediaCapabilities = true;
                 WebView.Settings.EnableMediaStream = true;
                 WebView.Settings.JavascriptCanAccessClipboard = true;


### PR DESCRIPTION
every html element keeps blinking(like the input method input blinking cursor), set caret browsing to false should fix this problem